### PR TITLE
FLRWSolver: work around Cactus include search path mangling

### DIFF
--- a/src/flrw_powerspecics.F90
+++ b/src/flrw_powerspecics.F90
@@ -12,7 +12,7 @@ module FLRW_PowerspecICs
   use, intrinsic :: iso_c_binding ! we need this for the fftw calls
   use FLRW_InitTools, only: pi,FLRW_Interp1DLinear,FLRW_GetRandomNormal3D
   implicit none
-  include 'fftw3.f03'
+# include "fftw3.f03"
 
 contains
 


### PR DESCRIPTION
Cactus' ExternalLibraries system removes the "system" locations from any INC_DIRS, but not all compilers look at the "well known" locations on their own. So the machine definition files (in the Einstein Toolkit) try to work around by setting CPATH which is however not used by gfortran, only by cpp.